### PR TITLE
b_queue: signal only if queue was empty

### DIFF
--- a/src/tef/b_queue.ml
+++ b/src/tef/b_queue.ml
@@ -29,8 +29,9 @@ let push (self : _ t) x : unit =
     Mutex.unlock self.mutex;
     raise Closed
   ) else (
+    let was_empty = Queue.is_empty self.q in
     Queue.push x self.q;
-    Condition.signal self.cond;
+    if was_empty then Condition.signal self.cond;
     Mutex.unlock self.mutex
   )
 


### PR DESCRIPTION
I noticed that the [example in the manual](https://v2.ocaml.org/api/Condition.html) only `signal` other threads when the queue was empty (before we `push`). I'm not sure how it matters to avoid unnecessary `Condition.sginal`, but it seems sensible to me since we only `wait` when the queue is empty anyway.