### PR TITLE
remove Trace module, focus on Trace_core

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -2,5 +2,4 @@
  (name trace)
  (public_name trace)
  (synopsis "Lightweight stub for tracing")
- (libraries (re_export trace.core))
-)
+ (libraries (re_export trace.core)))

--- a/src/dune
+++ b/src/dune
@@ -1,5 +1,6 @@
 (library
  (name trace)
  (public_name trace)
- (synopsis "Lightweight stub for tracing")
+ (synopsis "Lightweight stub for tracing (use `Trace_core` in code)")
+ (wrapped false)
  (libraries (re_export trace.core)))

--- a/src/trace.ml
+++ b/src/trace.ml
@@ -1,1 +1,0 @@
-include Trace_core

--- a/test/t1.ml
+++ b/test/t1.ml
@@ -1,3 +1,5 @@
+module Trace = Trace_core
+
 let run () =
   Trace.set_process_name "main";
   Trace.set_thread_name "t1";


### PR DESCRIPTION
remove `Trace` module, since it conflicts with toplevel. We can always use `Trace_core` and the `trace` library re-exports it.
