### PR TITLE
trace-tef: better queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _opam
 _build
 *.json
+*.exe

--- a/bench/dune
+++ b/bench/dune
@@ -1,0 +1,4 @@
+
+(executable
+  (name trace1)
+  (libraries trace.core trace-tef))

--- a/bench/trace1.ml
+++ b/bench/trace1.ml
@@ -1,0 +1,36 @@
+module Trace = Trace_core
+
+let ( let@ ) = ( @@ )
+
+let work ~n () : unit =
+  for _i = 1 to n do
+    let@ _sp =
+      Trace.with_span ~__FILE__ ~__LINE__ "outer" ~data:(fun () ->
+          [ "i", `Int _i ])
+    in
+    for _k = 1 to 10 do
+      let@ _sp = Trace.with_span ~__FILE__ ~__LINE__ "inner" in
+      ()
+    done;
+    Thread.delay 1e-6
+  done
+
+let main ~n ~j () : unit =
+  let domains = Array.init j (fun _ -> Domain.spawn (fun () -> work ~n ())) in
+  Array.iter Domain.join domains
+
+let () =
+  let@ () = Trace_tef.with_setup () in
+
+  let n = ref 10_000 in
+  let j = ref 4 in
+
+  let args =
+    [
+      "-n", Arg.Set_int n, " number of iterations";
+      "-j", Arg.Set_int j, " set number of workers";
+    ]
+    |> Arg.align
+  in
+  Arg.parse args ignore "bench1";
+  main ~n:!n ~j:!j ()

--- a/bench1.sh
+++ b/bench1.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+DUNE_OPTS="--profile=release --display=quiet"
+exec dune exec $DUNE_OPTS bench/trace1.exe -- $@

--- a/dune-project
+++ b/dune-project
@@ -29,6 +29,7 @@
    (trace (= :version))
    (mtime (>= 2.0))
    base-unix
+   atomic
    dune)
  (tags
   (trace tracing catapult)))

--- a/src/tef/b_queue.ml
+++ b/src/tef/b_queue.ml
@@ -1,8 +1,9 @@
 type 'a t = {
   mutex: Mutex.t;
   cond: Condition.t;
-  q: 'a Queue.t;
+  q: 'a Mpsc_queue.t;
   mutable closed: bool;
+  mutable consumer_waiting: bool;
 }
 
 exception Closed
@@ -11,8 +12,9 @@ let create () : _ t =
   {
     mutex = Mutex.create ();
     cond = Condition.create ();
-    q = Queue.create ();
+    q = Mpsc_queue.create ();
     closed = false;
+    consumer_waiting = false;
   }
 
 let close (self : _ t) =
@@ -24,50 +26,36 @@ let close (self : _ t) =
   Mutex.unlock self.mutex
 
 let push (self : _ t) x : unit =
-  Mutex.lock self.mutex;
-  if self.closed then (
-    Mutex.unlock self.mutex;
-    raise Closed
-  ) else (
-    let was_empty = Queue.is_empty self.q in
-    Queue.push x self.q;
-    if was_empty then Condition.broadcast self.cond;
+  if self.closed then raise Closed;
+  Mpsc_queue.enqueue self.q x;
+  if self.closed then raise Closed;
+  if self.consumer_waiting then (
+    (* wakeup consumer *)
+    Mutex.lock self.mutex;
+    Condition.broadcast self.cond;
     Mutex.unlock self.mutex
   )
 
-let pop (self : 'a t) : 'a =
-  Mutex.lock self.mutex;
-  let rec loop () =
-    if Queue.is_empty self.q then (
-      if self.closed then (
-        Mutex.unlock self.mutex;
-        raise Closed
-      );
-      Condition.wait self.cond self.mutex;
-      (loop [@tailcall]) ()
-    ) else (
-      let x = Queue.pop self.q in
-      Mutex.unlock self.mutex;
-      x
-    )
-  in
-  loop ()
+let rec pop (self : 'a t) : 'a =
+  match Mpsc_queue.dequeue self.q with
+  | x -> x
+  | exception Mpsc_queue.Empty ->
+    if self.closed then raise Closed;
+    Mutex.lock self.mutex;
+    self.consumer_waiting <- true;
+    Condition.wait self.cond self.mutex;
+    self.consumer_waiting <- false;
+    Mutex.unlock self.mutex;
+    pop self
 
-let transfer (self : 'a t) q2 : unit =
-  Mutex.lock self.mutex;
-  while
-    if Queue.is_empty self.q then (
-      if self.closed then (
-        Mutex.unlock self.mutex;
-        raise Closed
-      );
-      Condition.wait self.cond self.mutex;
-      true
-    ) else (
-      Queue.transfer self.q q2;
-      Mutex.unlock self.mutex;
-      false
-    )
-  do
-    ()
-  done
+let rec pop_all (self : 'a t) : 'a list =
+  match Mpsc_queue.dequeue_all self.q with
+  | l -> l
+  | exception Mpsc_queue.Empty ->
+    if self.closed then raise Closed;
+    Mutex.lock self.mutex;
+    self.consumer_waiting <- true;
+    Condition.wait self.cond self.mutex;
+    self.consumer_waiting <- false;
+    Mutex.unlock self.mutex;
+    pop_all self

--- a/src/tef/b_queue.mli
+++ b/src/tef/b_queue.mli
@@ -14,7 +14,7 @@ val pop : 'a t -> 'a
 (** [pop q] pops the next element in [q]. It might block until an element comes.
    @raise Closed if the queue was closed before a new element was available. *)
 
-val transfer : 'a t -> 'a Queue.t -> unit
+val pop_all : 'a t -> 'a list
 (** [transfer bq q2] transfers all items presently
     in [bq] into [q2], and clears [bq].
     It blocks if no element is in [bq]. *)

--- a/src/tef/dune
+++ b/src/tef/dune
@@ -3,4 +3,4 @@
   (name trace_tef)
   (public_name trace-tef)
   (synopsis "Simple and lightweight tracing using TEF/Catapult format, in-process")
-  (libraries trace.core mtime mtime.clock.os unix threads))
+  (libraries trace.core mtime mtime.clock.os atomic unix threads))

--- a/src/tef/dune
+++ b/src/tef/dune
@@ -3,4 +3,7 @@
   (name trace_tef)
   (public_name trace-tef)
   (synopsis "Simple and lightweight tracing using TEF/Catapult format, in-process")
-  (libraries trace.core mtime mtime.clock.os atomic unix threads))
+  (libraries trace.core mtime mtime.clock.os atomic unix threads
+             (select relax_.ml from
+                     (base-domain -> relax_.real.ml)
+                     ( -> relax_.dummy.ml))))

--- a/src/tef/mpsc_queue.ml
+++ b/src/tef/mpsc_queue.ml
@@ -18,7 +18,7 @@ module Backoff = struct
   let once (b : t) : t =
     let actual_b = b + Random.int 4 in
     for _i = 1 to actual_b do
-      Domain.cpu_relax ()
+      Relax_.cpu_relax ()
     done;
     min (b * 2) 256
 end

--- a/src/tef/mpsc_queue.ml
+++ b/src/tef/mpsc_queue.ml
@@ -1,0 +1,60 @@
+type 'a t = {
+  tail: 'a list Atomic.t;
+  head: 'a list ref;
+}
+
+let create () =
+  let tail = Atomic.make [] in
+  (* padding *)
+  ignore (Sys.opaque_identity (Array.make 16 ()));
+  let head = ref [] in
+  { tail; head }
+
+module Backoff = struct
+  type t = int
+
+  let default = 2
+
+  let once (b : t) : t =
+    let actual_b = b + Random.int 4 in
+    for _i = 1 to actual_b do
+      Domain.cpu_relax ()
+    done;
+    min (b * 2) 256
+end
+
+let rec enqueue backoff t x =
+  let before = Atomic.get t.tail in
+  let after = x :: before in
+  if not (Atomic.compare_and_set t.tail before after) then
+    enqueue (Backoff.once backoff) t x
+
+let enqueue t x = enqueue Backoff.default t x
+
+exception Empty
+
+let dequeue t =
+  match !(t.head) with
+  | x :: xs ->
+    t.head := xs;
+    x
+  | [] ->
+    (match Atomic.exchange t.tail [] with
+    | [] -> raise_notrace Empty
+    | [ x ] -> x
+    | x :: xs ->
+      (match List.rev_append [ x ] xs with
+      | x :: xs ->
+        t.head := xs;
+        x
+      | [] -> assert false))
+
+let dequeue_all t : _ list =
+  match !(t.head) with
+  | _ :: _ as l ->
+    t.head := [];
+    l
+  | [] ->
+    (match Atomic.exchange t.tail [] with
+    | [] -> raise_notrace Empty
+    | l -> List.rev l)

--- a/src/tef/mpsc_queue.mli
+++ b/src/tef/mpsc_queue.mli
@@ -1,6 +1,6 @@
 (** A multi-producer, single-consumer queue (from picos) *)
 
-type !'a t
+type 'a t
 
 val create : unit -> 'a t
 val enqueue : 'a t -> 'a -> unit

--- a/src/tef/mpsc_queue.mli
+++ b/src/tef/mpsc_queue.mli
@@ -1,0 +1,14 @@
+(** A multi-producer, single-consumer queue (from picos) *)
+
+type !'a t
+
+val create : unit -> 'a t
+val enqueue : 'a t -> 'a -> unit
+
+exception Empty
+
+val dequeue : 'a t -> 'a
+(** @raise Empty if empty *)
+
+val dequeue_all : 'a t -> 'a list
+(** @raise Empty if empty *)

--- a/src/tef/relax_.dummy.ml
+++ b/src/tef/relax_.dummy.ml
@@ -1,0 +1,1 @@
+let cpu_relax () = ()

--- a/src/tef/relax_.real.ml
+++ b/src/tef/relax_.real.ml
@@ -1,0 +1,1 @@
+let cpu_relax = Domain.cpu_relax

--- a/trace-tef.opam
+++ b/trace-tef.opam
@@ -14,6 +14,7 @@ depends: [
   "trace" {= version}
   "mtime" {>= "2.0"}
   "base-unix"
+  "atomic"
   "dune" {>= "2.9"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
wip: this should reduce a bit contention on the event logging queue
for trace-tef, by using a lock free algorithm where the consumer rarely competes
against producers.
